### PR TITLE
Study Groups MVP: per-course groups, invites, and My Groups

### DIFF
--- a/controllers/group-controller.js
+++ b/controllers/group-controller.js
@@ -1,0 +1,336 @@
+const mongoose = require("mongoose")
+const { Course, Group, GroupMember, User } = require("../models/db_schema")
+
+async function getMemberCounts(groupIds) {
+  if (!groupIds.length) return {}
+  const rows = await GroupMember.aggregate([
+    { $match: { groupId: { $in: groupIds.map(id => new mongoose.Types.ObjectId(id)) } } },
+    { $group: { _id: "$groupId", count: { $sum: 1 } } },
+  ])
+  const map = {}
+  for (const r of rows) map[String(r._id)] = r.count
+  return map
+}
+
+function ensureOwner(req, group) {
+  const userId = String(req.session.userId)
+  return String(group.ownerId) === userId
+}
+
+const renderCourseDetail = async (req, res) => {
+  try {
+    const courseId = req.params.courseId
+    const course = await Course.findById(courseId).lean()
+    if (!course) {
+      req.session.flash = { type: "error", message: "Course not found." }
+      return res.redirect("/courses")
+    }
+
+    const tab = req.query.tab === "groups" ? "groups" : "overview"
+
+    let groups = []
+    let memberCounts = {}
+    if (tab === "groups") {
+      const userId = req.session.userId
+      let myGroupIds = []
+      if (userId) {
+        const myMemberships = await GroupMember.find({ userId }).select("groupId").lean()
+        myGroupIds = myMemberships.map(m => m.groupId)
+      }
+      const query = { courseId: course._id, $or: [{ visibility: "public" }, { _id: { $in: myGroupIds } }] }
+      groups = await Group.find(query).sort({ createdAt: -1 }).lean()
+      memberCounts = await getMemberCounts(groups.map(g => g._id))
+      groups = groups.map(g => ({ ...g, memberCount: memberCounts[String(g._id)] || 0, isOwner: userId ? String(g.ownerId) === String(userId) : false }))
+    }
+
+    res.render("courses/detail.njk", { course, tab, groups })
+  } catch (err) {
+    console.error("renderCourseDetail error", err)
+    res.status(500)
+    res.render("500.njk")
+  }
+}
+
+const renderNewGroupForm = async (req, res) => {
+  try {
+    const courseId = req.query.course
+    const course = await Course.findById(courseId).lean()
+    if (!course) {
+      req.session.flash = { type: "error", message: "Course not found." }
+      return res.redirect("/courses")
+    }
+    const values = (res.locals.flash && res.locals.flash.values) || { name: "", description: "", visibility: "public", maxMembers: 25 }
+    const errors = (res.locals.flash && res.locals.flash.errors) || {}
+    res.render("groups/new.njk", { course, values, errors })
+  } catch (err) {
+    console.error("renderNewGroupForm error", err)
+    res.status(500).render("500.njk")
+  }
+}
+
+const createGroup = async (req, res) => {
+  try {
+    const { courseId, name, description, visibility, maxMembers } = req.body
+    const course = await Course.findById(courseId).lean()
+    const errors = {}
+    const values = { name: name?.trim() || "", description: description?.trim() || "", visibility: visibility || "public", maxMembers }
+
+    if (!course) errors.courseId = "Invalid course."
+    if (!name || name.trim().length < 2 || name.trim().length > 60) errors.name = "Name must be 2–60 characters."
+    if (description && description.trim().length > 500) errors.description = "Description too long (max 500)."
+    const vis = visibility === "private" ? "private" : "public"
+    let max = parseInt(maxMembers, 10)
+    if (Number.isNaN(max)) max = 25
+    if (max < 2 || max > 100) errors.maxMembers = "Max members must be between 2 and 100."
+
+    if (Object.keys(errors).length) {
+      req.session.flash = { type: "error", message: "Please fix the errors below.", errors, values }
+      return res.redirect(`/groups/new?course=${courseId}`)
+    }
+
+    const ownerId = req.session.userId
+    const group = new Group({ name: name.trim(), description: description?.trim() || "", visibility: vis, maxMembers: max, courseId, ownerId })
+    await group.save()
+    await GroupMember.create({ groupId: group._id, userId: ownerId, role: "owner" })
+
+    req.session.flash = { type: "success", message: "Study Group created." }
+    res.redirect(`/groups/${group._id}`)
+  } catch (err) {
+    console.error("createGroup error", err)
+    req.session.flash = { type: "error", message: "Failed to create group." }
+    res.redirect("/courses")
+  }
+}
+
+const resolveInvite = async (req, res) => {
+  try {
+    const { token } = req.params
+    const group = await Group.findOne({ inviteToken: token })
+    if (!group) {
+      req.session.flash = { type: "error", message: "Invalid or expired invite link." }
+      return res.redirect("/courses")
+    }
+
+    const now = new Date()
+    if (now > group.inviteTokenExpiresAt) {
+      req.session.flash = { type: "error", message: "This invite link has expired. Please ask the owner to regenerate a new link." }
+      return res.redirect(`/groups/${group._id}`)
+    }
+
+    if (!req.session?.userId) {
+      req.session.returnTo = req.originalUrl
+      req.session.flash = { type: "warning", message: "Please sign in to continue." }
+      return res.redirect("/login")
+    }
+
+    const count = await GroupMember.countDocuments({ groupId: group._id })
+    if (count >= group.maxMembers) {
+      req.session.flash = { type: "error", message: "This group is full." }
+      return res.redirect(`/groups/${group._id}`)
+    }
+
+    const userId = req.session.userId
+    const existing = await GroupMember.findOne({ groupId: group._id, userId })
+    if (!existing) {
+      await GroupMember.create({ groupId: group._id, userId, role: "member" })
+    }
+
+    req.session.flash = { type: "success", message: "You have joined the Study Group." }
+    res.redirect(`/groups/${group._id}`)
+  } catch (err) {
+    console.error("resolveInvite error", err)
+    req.session.flash = { type: "error", message: "Could not process invite." }
+    res.redirect("/courses")
+  }
+}
+
+const joinGroup = async (req, res) => {
+  try {
+    const groupId = req.params.id
+    const group = await Group.findById(groupId)
+    if (!group) {
+      req.session.flash = { type: "error", message: "Group not found." }
+      return res.redirect("/courses")
+    }
+    if (group.visibility === "private") {
+      req.session.flash = { type: "error", message: "This Study Group is private. You need an invite link to join." }
+      return res.redirect(`/groups/${group._id}`)
+    }
+
+    const count = await GroupMember.countDocuments({ groupId: group._id })
+    if (count >= group.maxMembers) {
+      req.session.flash = { type: "error", message: "This group is full." }
+      return res.redirect(`/groups/${group._id}`)
+    }
+
+    const userId = req.session.userId
+    const existing = await GroupMember.findOne({ groupId: group._id, userId })
+    if (!existing) await GroupMember.create({ groupId: group._id, userId, role: "member" })
+
+    req.session.flash = { type: "success", message: "Joined the Study Group." }
+    res.redirect(`/groups/${group._id}`)
+  } catch (err) {
+    console.error("joinGroup error", err)
+    req.session.flash = { type: "error", message: "Could not join group." }
+    res.redirect("/courses")
+  }
+}
+
+const leaveGroup = async (req, res) => {
+  try {
+    const groupId = req.params.id
+    const userId = req.session.userId
+    const group = await Group.findById(groupId)
+    if (!group) {
+      req.session.flash = { type: "error", message: "Group not found." }
+      return res.redirect("/courses")
+    }
+
+    const membership = await GroupMember.findOne({ groupId, userId })
+    if (!membership) {
+      req.session.flash = { type: "success", message: "You have left the group." }
+      return res.redirect(`/courses/${group.courseId}?tab=groups`)
+    }
+
+    const memberCount = await GroupMember.countDocuments({ groupId })
+
+    if (membership.role === "owner") {
+      if (memberCount > 1) {
+        req.session.flash = { type: "error", message: "Owner cannot leave while members exist." }
+        return res.redirect(`/groups/${groupId}`)
+      }
+      await GroupMember.deleteOne({ _id: membership._id })
+      await Group.deleteOne({ _id: groupId })
+      req.session.flash = { type: "success", message: "Group deleted." }
+      return res.redirect(`/courses/${group.courseId}?tab=groups`)
+    }
+
+    await GroupMember.deleteOne({ _id: membership._id })
+    req.session.flash = { type: "success", message: "You have left the group." }
+    res.redirect(`/courses/${group.courseId}?tab=groups`)
+  } catch (err) {
+    console.error("leaveGroup error", err)
+    req.session.flash = { type: "error", message: "Could not leave group." }
+    res.redirect("/courses")
+  }
+}
+
+const renderGroupDetail = async (req, res) => {
+  try {
+    const groupId = req.params.id
+    const group = await Group.findById(groupId).lean()
+    if (!group) {
+      req.session.flash = { type: "error", message: "Group not found." }
+      return res.redirect("/courses")
+    }
+
+    const course = await Course.findById(group.courseId).lean()
+    const members = await GroupMember.find({ groupId }).lean()
+    const userIds = members.map(m => m.userId)
+    const users = await User.find({ _id: { $in: userIds } }).lean()
+    const userMap = {}
+    for (const u of users) userMap[String(u._id)] = u
+
+    const enrichedMembers = members.map(m => ({ ...m, user: userMap[String(m.userId)] }))
+
+    const isOwner = req.session.userId ? String(group.ownerId) === String(req.session.userId) : false
+    const myMembership = req.session.userId ? members.find(m => String(m.userId) === String(req.session.userId)) : null
+
+    const expiresInMs = Math.max(0, new Date(group.inviteTokenExpiresAt).getTime() - Date.now())
+
+    res.render("groups/detail.njk", { group, course, members: enrichedMembers, isOwner, myMembership, expiresInMs })
+  } catch (err) {
+    console.error("renderGroupDetail error", err)
+    res.status(500)
+    res.render("500.njk")
+  }
+}
+
+const kickMember = async (req, res) => {
+  try {
+    const groupId = req.params.id
+    const targetUserId = req.params.userId
+    const group = await Group.findById(groupId)
+    if (!group) {
+      req.session.flash = { type: "error", message: "Group not found." }
+      return res.redirect("/courses")
+    }
+
+    if (!ensureOwner(req, group)) {
+      req.session.flash = { type: "error", message: "Forbidden." }
+      return res.status(403).redirect(`/groups/${groupId}`)
+    }
+
+    if (String(group.ownerId) === String(targetUserId)) {
+      req.session.flash = { type: "error", message: "Owner cannot be removed." }
+      return res.redirect(`/groups/${groupId}`)
+    }
+
+    await GroupMember.deleteOne({ groupId, userId: targetUserId })
+    req.session.flash = { type: "success", message: "Member removed." }
+    res.redirect(`/groups/${groupId}`)
+  } catch (err) {
+    console.error("kickMember error", err)
+    req.session.flash = { type: "error", message: "Could not remove member." }
+    res.redirect("/courses")
+  }
+}
+
+const regenerateInvite = async (req, res) => {
+  try {
+    const groupId = req.params.id
+    const group = await Group.findById(groupId)
+    if (!group) {
+      req.session.flash = { type: "error", message: "Group not found." }
+      return res.redirect("/courses")
+    }
+    if (!ensureOwner(req, group)) {
+      req.session.flash = { type: "error", message: "Forbidden." }
+      return res.status(403).redirect(`/groups/${groupId}`)
+    }
+
+    group.regenerateInvite()
+    await group.save()
+    req.session.flash = { type: "success", message: "Invite link regenerated." }
+    res.redirect(`/groups/${groupId}`)
+  } catch (err) {
+    console.error("regenerateInvite error", err)
+    req.session.flash = { type: "error", message: "Could not regenerate invite." }
+    res.redirect("/courses")
+  }
+}
+
+const listMyGroups = async (req, res) => {
+  try {
+    const userId = req.session.userId
+    const memberships = await GroupMember.find({ userId }).lean()
+    const groupIds = memberships.map(m => m.groupId)
+    const groups = await Group.find({ _id: { $in: groupIds } }).lean()
+    const courseIds = Array.from(new Set(groups.map(g => String(g.courseId))))
+    const courses = await Course.find({ _id: { $in: courseIds } }).lean()
+    const courseMap = {}
+    for (const c of courses) courseMap[String(c._id)] = c
+
+    const memberCounts = await getMemberCounts(groups.map(g => g._id))
+
+    const items = groups.map(g => ({ group: g, course: courseMap[String(g.courseId)], memberCount: memberCounts[String(g._id)] || 0, role: memberships.find(m => String(m.groupId) === String(g._id))?.role || "member" }))
+
+    res.render("me/groups.njk", { items })
+  } catch (err) {
+    console.error("listMyGroups error", err)
+    res.status(500).render("500.njk")
+  }
+}
+
+module.exports = {
+  renderCourseDetail,
+  renderNewGroupForm,
+  createGroup,
+  resolveInvite,
+  joinGroup,
+  leaveGroup,
+  renderGroupDetail,
+  kickMember,
+  regenerateInvite,
+  listMyGroups,
+}

--- a/controllers/user_controller.js
+++ b/controllers/user_controller.js
@@ -72,7 +72,9 @@ const loginUser = async (req, res) => {
     req.session.username = user.username
     req.session.userEmail = user.email
     req.session.flash = { type: 'success', message: 'Signed in successfully.' }
-    res.redirect('/courses')
+    const returnTo = req.session.returnTo || '/courses'
+    req.session.returnTo = null
+    res.redirect(returnTo)
   } catch (error) {
     console.log('Login error', error)
     req.session.flash = { type: 'error', message: 'Something went wrong.' }

--- a/models/db_schema.js
+++ b/models/db_schema.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose")
+const crypto = require("crypto")
 
 const userSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
@@ -15,8 +16,51 @@ const courseSchema = new mongoose.Schema({
 courseSchema.index({ title: 1 })
 courseSchema.index({ linktoTheCall: 1 })
 
+const groupSchema = new mongoose.Schema({
+  name: { type: String, required: true, trim: true, minlength: 2, maxlength: 60 },
+  courseId: { type: mongoose.Schema.Types.ObjectId, ref: "Course", required: true, index: true },
+  ownerId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true, index: true },
+  description: { type: String, trim: true, maxlength: 500 },
+  visibility: { type: String, enum: ["public", "private"], default: "public" },
+  inviteToken: { type: String, required: true, unique: true, index: true },
+  inviteTokenExpiresAt: { type: Date, required: true },
+  maxMembers: { type: Number, default: 25, min: 2, max: 100 },
+}, { timestamps: true })
+
+groupSchema.index({ courseId: 1, name: 1 })
+
+groupSchema.pre("validate", function(next) {
+  if (!this.inviteToken) {
+    this.inviteToken = crypto.randomBytes(16).toString("hex")
+  }
+  if (!this.inviteTokenExpiresAt) {
+    const expires = new Date()
+    expires.setDate(expires.getDate() + 7)
+    this.inviteTokenExpiresAt = expires
+  }
+  next()
+})
+
+groupSchema.methods.regenerateInvite = function() {
+  this.inviteToken = crypto.randomBytes(16).toString("hex")
+  const expires = new Date()
+  expires.setDate(expires.getDate() + 7)
+  this.inviteTokenExpiresAt = expires
+}
+
+const groupMemberSchema = new mongoose.Schema({
+  groupId: { type: mongoose.Schema.Types.ObjectId, ref: "Group", required: true, index: true },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true, index: true },
+  role: { type: String, enum: ["owner", "member"], default: "member" },
+  joinedAt: { type: Date, default: Date.now },
+})
+
+groupMemberSchema.index({ groupId: 1, userId: 1 }, { unique: true })
+
 const User = mongoose.model("User", userSchema)
 // Map to legacy collection name 'subjects' to avoid data loss
 const Course = mongoose.model("Course", courseSchema, "subjects")
+const Group = mongoose.model("Group", groupSchema)
+const GroupMember = mongoose.model("GroupMember", groupMemberSchema)
 
-module.exports = { User, Course }
+module.exports = { User, Course, Group, GroupMember }

--- a/routes/group-router.js
+++ b/routes/group-router.js
@@ -1,0 +1,33 @@
+const { requireAuth } = require("../middleware/auth")
+const {
+  renderCourseDetail,
+  renderNewGroupForm,
+  createGroup,
+  resolveInvite,
+  joinGroup,
+  leaveGroup,
+  renderGroupDetail,
+  kickMember,
+  regenerateInvite,
+  listMyGroups,
+} = require("../controllers/group-controller")
+
+const router = require("express").Router()
+
+router.get("/courses/:courseId", requireAuth, renderCourseDetail)
+
+router.get("/groups/new", requireAuth, renderNewGroupForm)
+router.post("/groups", requireAuth, createGroup)
+
+router.get("/g/:token", resolveInvite)
+
+router.post("/groups/:id/join", requireAuth, joinGroup)
+router.post("/groups/:id/leave", requireAuth, leaveGroup)
+
+router.get("/groups/:id", requireAuth, renderGroupDetail)
+router.post("/groups/:id/kick/:userId", requireAuth, kickMember)
+router.post("/groups/:id/invite/regenerate", requireAuth, regenerateInvite)
+
+router.get("/me/groups", requireAuth, listMyGroups)
+
+module.exports = router

--- a/server.js
+++ b/server.js
@@ -37,10 +37,12 @@ app.use((req, res, next) => {
 const userRoutes = require("./routes/user_router")
 const courseRoutes = require("./routes/course-router")
 const subjectRedirectRoutes = require("./routes/subject-router")
+const groupRoutes = require("./routes/group-router")
 
 app.use("/", userRoutes)
 app.use("/", courseRoutes)
 app.use("/", subjectRedirectRoutes)
+app.use("/", groupRoutes)
 
 app.use((req, res) => {
   res.status(404)

--- a/views/course-list.njk
+++ b/views/course-list.njk
@@ -23,6 +23,9 @@
           <p class="mt-1 text-sm text-gray-600 truncate" title="{{ course.linktoTheCall }}">
             <a href="{{ course.linktoTheCall }}" target="_blank" rel="noopener" class="text-primary hover:underline">{{ course.linktoTheCall }}</a>
           </p>
+          <div class="mt-4">
+            <a href="/courses/{{ course._id }}" class="btn-secondary">View Course</a>
+          </div>
         </div>
       </article>
     {% endfor %}

--- a/views/courses/detail.njk
+++ b/views/courses/detail.njk
@@ -1,0 +1,58 @@
+{% extends "layout.njk" %}
+{% block content %}
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold">{{ course.title }}</h1>
+      <p class="mt-1 text-sm text-gray-600">
+        <a href="{{ course.linktoTheCall }}" target="_blank" rel="noopener" class="text-primary hover:underline">Join call</a>
+      </p>
+    </div>
+    <div>
+      <a href="/courses" class="btn-secondary">Back to Courses</a>
+    </div>
+  </div>
+
+  <div class="mt-6 border-b border-gray-200">
+    <nav class="-mb-px flex space-x-6" aria-label="Tabs">
+      <a href="/courses/{{ course._id }}?tab=overview" class="whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium {{ tab == 'overview' ? 'border-primary text-primary' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300' }}">Overview</a>
+      <a href="/courses/{{ course._id }}?tab=groups" class="whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium {{ tab == 'groups' ? 'border-primary text-primary' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300' }}">Study Groups</a>
+    </nav>
+  </div>
+
+  {% if tab == 'overview' %}
+    <div class="mt-6">
+      <div class="prose prose-sm max-w-none">
+        <p>This is the course overview. Use the Study Groups tab to create or join a group.</p>
+      </div>
+    </div>
+  {% else %}
+    <div class="mt-6 flex items-center justify-between">
+      <h2 class="text-lg font-semibold">Study Groups</h2>
+      <a href="/groups/new?course={{ course._id }}" class="btn-primary">Create Study Group</a>
+    </div>
+
+    {% if groups and groups | length > 0 %}
+      <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {% for g in groups %}
+          <article class="card">
+            <div class="p-4">
+              <div class="flex items-center justify-between">
+                <h3 class="text-lg font-semibold truncate" title="{{ g.name }}">{{ g.name }}</h3>
+                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ g.visibility == 'public' ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-700' }}">{{ g.visibility | capitalize }}</span>
+              </div>
+              <p class="mt-1 text-sm text-gray-600">Members: {{ g.memberCount }}</p>
+              <div class="mt-4 flex items-center justify-between">
+                <a href="/groups/{{ g._id }}" class="btn-secondary">View</a>
+                {% if g.isOwner %}
+                  <span class="text-xs text-gray-500">Owner</span>
+                {% endif %}
+              </div>
+            </div>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="mt-4 text-gray-600">No Study Groups yet. Be the first to create one!</p>
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/views/groups/detail.njk
+++ b/views/groups/detail.njk
@@ -1,0 +1,95 @@
+{% extends "layout.njk" %}
+{% block content %}
+  <div class="flex items-center justify-between">
+    <div>
+      <div class="flex items-center gap-3">
+        <h1 class="text-2xl font-semibold">{{ group.name }}</h1>
+        <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ group.visibility == 'public' ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-700' }}">{{ group.visibility | capitalize }}</span>
+      </div>
+      <p class="mt-1 text-sm text-gray-600">Course: <a href="/courses/{{ course._id }}?tab=groups" class="text-primary hover:underline">{{ course.title }}</a></p>
+    </div>
+    <div>
+      <a href="/courses/{{ course._id }}?tab=groups" class="btn-secondary">Back</a>
+    </div>
+  </div>
+
+  {% if isOwner %}
+    <section class="mt-6">
+      <h2 class="text-lg font-semibold">Invite</h2>
+      <div class="mt-2 flex items-center gap-2">
+        <input type="text" id="inviteLink" class="input flex-1" readonly value="/g/{{ group.inviteToken }}" />
+        <button id="copyBtn" class="btn-secondary" type="button">Copy</button>
+        <form action="/groups/{{ group._id }}/invite/regenerate" method="POST" class="inline">
+          <button class="btn-secondary" type="submit">Regenerate</button>
+        </form>
+      </div>
+      <p id="expiryText" class="mt-1 text-sm text-gray-600">Invite expires soon.</p>
+    </section>
+  {% endif %}
+
+  <section class="mt-8">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold">Members ({{ members | length }})</h2>
+      <div>
+        {% if myMembership %}
+          <form action="/groups/{{ group._id }}/leave" method="POST" class="inline">
+            <button class="btn-secondary" type="submit">Leave Group</button>
+          </form>
+        {% else %}
+          {% if group.visibility == 'public' %}
+            <form action="/groups/{{ group._id }}/join" method="POST" class="inline">
+              <button class="btn-primary" type="submit">Join Group</button>
+            </form>
+          {% else %}
+            <span class="text-sm text-gray-600">Private group — join via invite link.</span>
+          {% endif %}
+        {% endif %}
+      </div>
+    </div>
+
+    <ul class="mt-4 divide-y divide-gray-200 bg-white shadow rounded-md">
+      {% for m in members %}
+        <li class="p-4 flex items-center justify-between">
+          <div>
+            <div class="font-medium">{{ m.user?.username or 'User' }}</div>
+            <div class="text-sm text-gray-600">{{ m.role | capitalize }}</div>
+          </div>
+          {% if isOwner and m.role != 'owner' %}
+            <form action="/groups/{{ group._id }}/kick/{{ m.userId }}" method="POST">
+              <button class="btn-secondary" type="submit">Kick</button>
+            </form>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  <script>
+    const expiresInMs = {{ expiresInMs | default(0) }}
+    function humanize(ms) {
+      const s = Math.floor(ms / 1000)
+      const d = Math.floor(s / 86400)
+      const h = Math.floor((s % 86400) / 3600)
+      const m = Math.floor((s % 3600) / 60)
+      if (d > 0) return `${d}d ${h}h ${m}m`
+      if (h > 0) return `${h}h ${m}m`
+      if (m > 0) return `${m}m`
+      return 'less than a minute'
+    }
+    const expiryText = document.getElementById('expiryText')
+    if (expiryText && expiresInMs > 0) {
+      expiryText.textContent = `Invite expires in ${humanize(expiresInMs)}`
+    }
+    const copyBtn = document.getElementById('copyBtn')
+    const inviteLink = document.getElementById('inviteLink')
+    if (copyBtn && inviteLink) {
+      copyBtn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(inviteLink.value)
+          copyBtn.textContent = 'Copied!'
+          setTimeout(() => { copyBtn.textContent = 'Copy' }, 1500)
+        } catch (e) {}
+      })
+    }
+  </script>
+{% endblock %}

--- a/views/groups/new.njk
+++ b/views/groups/new.njk
@@ -1,0 +1,42 @@
+{% extends "layout.njk" %}
+{% block content %}
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold">Create Study Group</h1>
+    <a href="/courses/{{ course._id }}?tab=groups" class="btn-secondary">Back</a>
+  </div>
+
+  <form action="/groups" method="POST" class="mt-6 max-w-2xl space-y-5">
+    <input type="hidden" name="courseId" value="{{ course._id }}" />
+
+    <div>
+      <label for="name" class="label">Name</label>
+      <input type="text" id="name" name="name" value="{{ values.name }}" class="input" required minlength="2" maxlength="60" />
+      {% if errors.name %}<p class="mt-1 text-sm text-red-600">{{ errors.name }}</p>{% endif %}
+    </div>
+
+    <div>
+      <label for="description" class="label">Description (optional)</label>
+      <textarea id="description" name="description" rows="3" maxlength="500" class="input">{{ values.description }}</textarea>
+      {% if errors.description %}<p class="mt-1 text-sm text-red-600">{{ errors.description }}</p>{% endif %}
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label for="visibility" class="label">Visibility</label>
+        <select id="visibility" name="visibility" class="input">
+          <option value="public" {{ values.visibility == 'public' ? 'selected' : '' }}>Public</option>
+          <option value="private" {{ values.visibility == 'private' ? 'selected' : '' }}>Private</option>
+        </select>
+      </div>
+      <div>
+        <label for="maxMembers" class="label">Max members (2–100)</label>
+        <input type="number" id="maxMembers" name="maxMembers" min="2" max="100" value="{{ values.maxMembers or 25 }}" class="input" />
+        {% if errors.maxMembers %}<p class="mt-1 text-sm text-red-600">{{ errors.maxMembers }}</p>{% endif %}
+      </div>
+    </div>
+
+    <div class="pt-2">
+      <button type="submit" class="btn-primary">Create Group</button>
+    </div>
+  </form>
+{% endblock %}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -24,6 +24,7 @@
             {% if currentUser %}
               <a href="/courses" class="text-sm font-medium text-gray-700 hover:text-primary">Courses</a>
               <a href="/courses/add" class="text-sm font-medium text-gray-700 hover:text-primary">Add Course</a>
+              <a href="/me/groups" class="text-sm font-medium text-gray-700 hover:text-primary">My Groups</a>
               <form action="/logout" method="POST" class="inline">
                 <button class="btn-secondary">Logout</button>
               </form>
@@ -45,6 +46,7 @@
             {% if currentUser %}
               <a href="/courses" class="px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md">Courses</a>
               <a href="/courses/add" class="px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md">Add Course</a>
+              <a href="/me/groups" class="px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md">My Groups</a>
               <form action="/logout" method="POST" class="px-2 py-1">
                 <button class="w-full btn-secondary">Logout</button>
               </form>

--- a/views/me/groups.njk
+++ b/views/me/groups.njk
@@ -1,0 +1,25 @@
+{% extends "layout.njk" %}
+{% block content %}
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-semibold">My Study Groups</h1>
+  </div>
+
+  {% if items and items | length > 0 %}
+    <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {% for it in items %}
+        <article class="card">
+          <div class="p-4">
+            <p class="text-sm text-gray-500">{{ it.course.title }}</p>
+            <h3 class="mt-1 text-lg font-semibold truncate">{{ it.group.name }}</h3>
+            <p class="mt-1 text-sm text-gray-600">Members: {{ it.memberCount }} • {{ it.role | capitalize }}</p>
+            <div class="mt-4">
+              <a href="/groups/{{ it.group._id }}" class="btn-secondary">Open</a>
+            </div>
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="mt-6 text-gray-600">You're not in any Study Groups yet.</p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Summary
- Introduces Study Groups to enable peer collaboration within each Course.
- Invite-based joining with 7-day token expiry; capacity controls (default 25, max 100).
- Adds Course detail page with tabs (Overview | Study Groups), Group detail, New Group form, and My Groups.

Why
- Students need lightweight coordination spaces per course. This MVP lets them create, discover, and join small groups with simple moderation.

Key changes
Models (Mongoose)
- Group: name, courseId, ownerId, description, visibility (public/private), inviteToken (+ expiry), maxMembers (default 25; min 2, max 100). Pre-validate sets token+expiry; instance method regenerateInvite(). Indexes: inviteToken unique; (courseId,name) compound.
- GroupMember: groupId, userId, role (owner/member), joinedAt. Unique compound index (groupId,userId) prevents duplicates. Owner membership is created on group creation.

Controllers
- controllers/group-controller.js implements: renderCourseDetail, renderNewGroupForm, createGroup, resolveInvite (/g/:token), joinGroup, leaveGroup, renderGroupDetail, kickMember (owner-only), regenerateInvite (owner-only), listMyGroups.

Routes
- routes/group-router.js mounts:
  - GET /courses/:courseId (detail w/ tabs)
  - GET /groups/new?course=:id
  - POST /groups
  - GET /groups/:id
  - POST /groups/:id/join
  - POST /groups/:id/leave
  - POST /groups/:id/kick/:userId (owner-only)
  - POST /groups/:id/invite/regenerate (owner-only)
  - GET /g/:token (unauth allowed; redirects to login then back)
- server.js mounts groupRouter after sessions/flash.

Views (Tailwind + Nunjucks)
- views/courses/detail.njk: Course header; tabs for Overview | Study Groups; list groups with name, member count, and visibility; Create Study Group CTA.
- views/groups/new.njk: Create form with name, description, visibility, maxMembers.
- views/groups/detail.njk: Group info, invite link (owner only) with copy + expiry indicator; members list w/ roles; Join/Leave; owner Kick + Regenerate.
- views/me/groups.njk: "My Study Groups" listing.
- views/layout.njk: Adds "My Groups" link when logged in.
- views/course-list.njk: Adds "View Course" CTA linking to /courses/:id.

Behavior & validation
- Auth required for all routes except GET /g/:token. If unauthenticated on /g/:token, user is sent to /login and redirected back after login (returnTo support added).
- Owner-only guards on kick/regenerate; 403 + flash on violations.
- Enforces maxMembers on join/resolve; joining is idempotent.
- Invite expiry: 7 days; expired invites are blocked with a clear message; owners can regenerate.

Indexes & data integrity
- Unique (groupId,userId) on GroupMember.
- Unique inviteToken on Group.
- (courseId,name) compound index on Group (non-unique) to aid lookups.

Defaults
- maxMembers default: 25; allowed range: 2–100.

Acceptance criteria
- Authenticated users can create and join Groups (via invite within 7 days or explicit join for public groups).
- Owner can remove members, see/copy invite link with visible expiry, and regenerate.
- Course detail page (Overview | Study Groups) + updated course cards.
- "My Groups" lists memberships.
- Protected routes + flash messaging; expired/over-capacity invites blocked.

Notes
- New collections will be created by Mongoose for Group and GroupMember; indexes build automatically.
- No breaking changes to existing Courses model (still mapped to legacy `subjects` collection).

QA tips
- Create a Course, then create a Study Group (default Public). Copy /g/:token in Group detail, open in another browser/session to join. Use Regenerate to verify expiry resets. Verify capacity by lowering maxMembers and attempting to overfill.
